### PR TITLE
Implement markdown rendering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ name = "rustdoc"
 version = "0.0.0"
 
 [dependencies]
+pulldown-cmark = "0.0.8"
+hamlet = "0.2"
+cmark-hamlet = "0.0.2"

--- a/src/html/markdown.rs
+++ b/src/html/markdown.rs
@@ -203,6 +203,9 @@ pub fn render(w: &mut fmt::Formatter, md: &str, _: bool) -> fmt::Result {
             HmToken::EndTag { name: Cow::Borrowed("pre") } if rust_block => {
                 rust_block = false;
             }
+            HmToken::EndTag { name: Cow::Borrowed("p") } => {
+                try!(write!(w, "{}\n\n", hm_tok)); // hack to make render::shorter() work
+            }
             _ => try!(write!(w, "{}", hm_tok)),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ extern crate std_unicode;
 extern crate rustc_errors as errors;
 
 extern crate pulldown_cmark as cmark;
-extern crate hamlet;
+#[macro_use] extern crate hamlet;
 extern crate cmark_hamlet;
 
 extern crate serialize as rustc_serialize; // used by deriving

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,10 @@ extern crate std_unicode;
 #[macro_use] extern crate log;
 extern crate rustc_errors as errors;
 
+extern crate pulldown_cmark as cmark;
+extern crate hamlet;
+extern crate cmark_hamlet;
+
 extern crate serialize as rustc_serialize; // used by deriving
 
 use std::collections::{BTreeMap, BTreeSet};


### PR DESCRIPTION
- [x] Make it work for `cargo doc`
  - [x] Proper html tags
  - [x] Proper styling and `id`s (needs more testing)
  - [x] Proper `docblock-short` rendering ([ref](https://github.com/critiqjo/rustdoc/blob/93c80bf/src/html/render.rs#L1816))
- [x] Make it work for `cargo test` ([ref](https://github.com/critiqjo/rustdoc/blob/93c80bf/src/html/markdown.rs#L215))
- [ ] Book support: `MarkdownWithToc` ([ref](https://github.com/critiqjo/rustdoc/blob/93c80bf/src/html/markdown.rs#L323))
- [x] Pass the tests (test cases were modified -- see acc5a5f)

[Compare all changes](https://github.com/critiqjo/rustdoc/compare/242dbdb...cmark?w=1)
